### PR TITLE
Test/budget/js

### DIFF
--- a/src/usecases/budget/budget.service.ts
+++ b/src/usecases/budget/budget.service.ts
@@ -87,16 +87,18 @@ export class BudgetService extends BudgetUseCase {
 	}: CreateBasicInput): Promise<Budget> {
 		const itemsFormatted = items
 			.map(({ categoryId, amount }) =>
-				Array(12).map((_, idx) => ({
-					month: idx + 1,
-					year,
-					items: [
-						{
-							categoryId,
-							amount,
-						},
-					],
-				})),
+				Array(12)
+					.fill(null)
+					.map((_, idx) => ({
+						month: idx + 1,
+						year,
+						items: [
+							{
+								categoryId,
+								amount,
+							},
+						],
+					})),
 			)
 			.flat();
 
@@ -143,7 +145,7 @@ export class BudgetService extends BudgetUseCase {
 			budgetByCategory: categories
 				// Only return categories that are active and
 				// inactive categories that have some kind of expense
-				.filter((c) => !c.active && expensesByCategoryId[c.id] === 0)
+				.filter((c) => c.active || expensesByCategoryId[c.id] > 0)
 				.map(({ accountId: _, ...c }) => ({
 					...c,
 					totalExpenses: expensesByCategoryId[c.id],

--- a/tests/mocks/adapters/dayjs.ts
+++ b/tests/mocks/adapters/dayjs.ts
@@ -1,0 +1,35 @@
+import type { Mock } from '../types';
+import { DateAdapter } from 'adapters/date';
+import { DayjsAdapterService } from 'adapters/implementations/dayjs/dayjs.service';
+
+export const makeDayjsAdapterMock = () => {
+	const mock: Mock<DateAdapter> = {
+		today: jest.fn(),
+		newDate: jest.fn(),
+		get: jest.fn(),
+		diff: jest.fn(),
+		getDayOfWeek: jest.fn(),
+		getNextMonths: jest.fn(),
+		format: jest.fn(),
+		statementDate: jest.fn(),
+		dueDate: jest.fn(),
+		isSameMonth: jest.fn(),
+		isAfterToday: jest.fn(),
+		nowPlus: jest.fn(),
+		setDay: jest.fn(),
+		add: jest.fn(),
+		sub: jest.fn(),
+		startOf: jest.fn(),
+		endOf: jest.fn(),
+	};
+
+	const module = {
+		provide: DayjsAdapterService,
+		useValue: mock,
+	};
+
+	return {
+		mock,
+		module,
+	};
+};

--- a/tests/mocks/repositories/postgres/budget.ts
+++ b/tests/mocks/repositories/postgres/budget.ts
@@ -1,0 +1,46 @@
+import { BudgetRepository } from 'models/budget';
+import type { Mock } from '../../types';
+import { BudgetRepositoryService } from 'repositories/postgres/budget/budget-repository.service';
+
+export const makeBudgetRepositoryMock = () => {
+	const mock: Mock<BudgetRepository> = {
+		createWithItems: jest.fn(),
+		getBudgetDateById: jest.fn(),
+		getMonthlyByCategory: jest.fn(),
+		upsertManyBudgetDates: jest.fn(),
+	};
+
+	const module = {
+		provide: BudgetRepositoryService,
+		useValue: mock,
+	};
+
+	const outputs = {
+		createWithItems: {
+			id: '1',
+			accountId: 'accountId',
+			name: 'Test Budget',
+			description: 'Test Budget Description',
+		},
+		upsertManyBudgetDates: [
+			{
+				id: '1',
+				budgetId: '1',
+				month: 1,
+				year: 2024,
+				date: new Date(2024, 1, 24, 3, 0, 0),
+			},
+		],
+		getMonthlyByCategory: [
+			{
+				categoryId: 'categoryId',
+				amount: 100,
+			},
+		],
+	};
+	return {
+		mock,
+		module,
+		outputs,
+	};
+};

--- a/tests/mocks/repositories/postgres/budget.ts
+++ b/tests/mocks/repositories/postgres/budget.ts
@@ -17,26 +17,36 @@ export const makeBudgetRepositoryMock = () => {
 
 	const outputs = {
 		createWithItems: {
-			id: '1',
-			accountId: 'accountId',
-			name: 'Test Budget',
-			description: 'Test Budget Description',
-		},
-		upsertManyBudgetDates: [
-			{
+			sucess: {
 				id: '1',
-				budgetId: '1',
-				month: 1,
-				year: 2024,
-				date: new Date(2024, 1, 24, 3, 0, 0),
+				accountId: 'accountId',
+				name: 'Test Budget',
+				description: 'Test Budget Description',
 			},
-		],
-		getMonthlyByCategory: [
-			{
-				categoryId: 'categoryId',
-				amount: 100,
-			},
-		],
+		},
+		upsertManyBudgetDates: {
+			sucess: [
+				{
+					id: '1',
+					budgetId: '1',
+					month: 1,
+					year: 2024,
+					date: new Date(2024, 1, 24, 3, 0, 0),
+				},
+			],
+		},
+		getMonthlyByCategory: {
+			positiveBudget: [
+				{ categoryId: 1, amount: 100 },
+				{ categoryId: 2, amount: 200 },
+				{ categoryId: 3, amount: 150 },
+			],
+			negativeBudget: [
+				{ categoryId: 1, amount: -50 },
+				{ categoryId: 2, amount: 20 },
+				{ categoryId: 3, amount: 150 },
+			],
+		},
 	};
 	return {
 		mock,

--- a/tests/mocks/repositories/postgres/category.ts
+++ b/tests/mocks/repositories/postgres/category.ts
@@ -1,0 +1,38 @@
+import { CategoryRepository } from 'models/category';
+import type { Mock } from '../../types';
+import { CategoryRepositoryService } from 'repositories/postgres/category/category-repository.service';
+import { IconEnum } from '@prisma/client';
+
+export const makeCategoryRepositoryMock = () => {
+	const mock: Mock<CategoryRepository> = {
+		createMany: jest.fn(),
+		getById: jest.fn(),
+		getByUser: jest.fn(),
+		getDefault: jest.fn(),
+	};
+
+	const outputs = {
+		getByUser: [
+			{
+				id: '1',
+				accountId: 'accountId',
+				name: 'name',
+				description: 'description',
+				icon: IconEnum.bank,
+				color: 'red',
+				active: true,
+			},
+		],
+	};
+
+	const module = {
+		provide: CategoryRepositoryService,
+		useValue: mock,
+	};
+
+	return {
+		outputs,
+		mock,
+		module,
+	};
+};

--- a/tests/mocks/repositories/postgres/category.ts
+++ b/tests/mocks/repositories/postgres/category.ts
@@ -12,17 +12,67 @@ export const makeCategoryRepositoryMock = () => {
 	};
 
 	const outputs = {
-		getByUser: [
-			{
-				id: '1',
-				accountId: 'accountId',
-				name: 'name',
-				description: 'description',
-				icon: IconEnum.bank,
-				color: 'red',
-				active: true,
-			},
-		],
+		getByUser: {
+			activeCategory: [
+				{
+					id: 1,
+					accountId: 'accountId1',
+					name: 'Category A',
+					description: 'description',
+					icon: IconEnum.bank,
+					color: 'red',
+					active: true,
+				},
+				{
+					id: 2,
+					accountId: 'accountId2',
+					name: 'Category B',
+					description: 'description',
+					icon: IconEnum.bank,
+					color: 'red',
+					active: true,
+				},
+				{
+					id: 3,
+					accountId: 'accountId3',
+					name: 'Category C',
+					description: 'description',
+					icon: IconEnum.bank,
+					color: 'red',
+					active: true,
+				},
+			],
+
+			inactiveCategory: [
+				{
+					id: 1,
+					accountId: 'accountId1',
+					name: 'Category A',
+					description: 'description',
+					icon: IconEnum.bank,
+					color: 'red',
+					active: false,
+				},
+				{
+					id: 2,
+					accountId: 'accountId2',
+					name: 'Category B',
+					description: 'description',
+					icon: IconEnum.bank,
+					color: 'red',
+					active: false,
+				},
+				{
+					id: 3,
+					accountId: 'accountId3',
+					name: 'Category C',
+					description: 'description',
+					icon: IconEnum.bank,
+					color: 'red',
+					active: false,
+				},
+			],
+		},
 	};
 
 	const module = {

--- a/tests/mocks/repositories/postgres/transaction.ts
+++ b/tests/mocks/repositories/postgres/transaction.ts
@@ -1,0 +1,33 @@
+import { TransactionRepository } from 'models/transaction';
+import type { Mock } from '../../types';
+import { TransactionRepositoryService } from 'repositories/postgres/transaction/transaction-repository.service';
+
+export const makeTransactionRepositoryMock = () => {
+	const mock: Mock<TransactionRepository> = {
+		createCredit: jest.fn(),
+		createInOut: jest.fn(),
+		createTransfer: jest.fn(),
+		getByBudget: jest.fn(),
+		getMonthlyAmountByCategory: jest.fn(),
+	};
+
+	const outputs = {
+		getMonthlyAmountByCategory: [
+			{
+				categoryId: 'categoryId',
+				amount: 100,
+			},
+		],
+	};
+
+	const module = {
+		provide: TransactionRepositoryService,
+		useValue: mock,
+	};
+
+	return {
+		outputs,
+		mock,
+		module,
+	};
+};

--- a/tests/mocks/repositories/postgres/transaction.ts
+++ b/tests/mocks/repositories/postgres/transaction.ts
@@ -12,12 +12,18 @@ export const makeTransactionRepositoryMock = () => {
 	};
 
 	const outputs = {
-		getMonthlyAmountByCategory: [
-			{
-				categoryId: 'categoryId',
-				amount: 100,
-			},
-		],
+		getMonthlyAmountByCategory: {
+			expensePositive: [
+				{ categoryId: 1, amount: 50 },
+				{ categoryId: 2, amount: 0 },
+				{ categoryId: 3, amount: 100 },
+			],
+			expenseNegative: [
+				{ categoryId: 1, amount: 100 },
+				{ categoryId: 2, amount: -50 },
+				{ categoryId: 3, amount: 200 },
+			],
+		},
 	};
 
 	const module = {

--- a/tests/mocks/usecases/account.ts
+++ b/tests/mocks/usecases/account.ts
@@ -1,0 +1,23 @@
+import type { AccountUseCase } from 'models/account';
+import { AccountService } from 'usecases/account/account.service';
+import type { Mock } from '../types';
+
+export const makeAccountServiceMock = () => {
+	const mock: Mock<AccountUseCase> = {
+		getOnboarding: jest.fn(),
+		iam: jest.fn(),
+		setBudget: jest.fn(),
+		updateName: jest.fn(),
+		updateOnboarding: jest.fn(),
+	};
+
+	const module = {
+		provide: AccountService,
+		useValue: mock,
+	};
+
+	return {
+		mock,
+		module,
+	};
+};

--- a/tests/mocks/usecases/account.ts
+++ b/tests/mocks/usecases/account.ts
@@ -11,6 +11,11 @@ export const makeAccountServiceMock = () => {
 		updateOnboarding: jest.fn(),
 	};
 
+	const outputs = {
+		setBudget: {
+			sucess: undefined,
+		},
+	};
 	const module = {
 		provide: AccountService,
 		useValue: mock,
@@ -18,6 +23,7 @@ export const makeAccountServiceMock = () => {
 
 	return {
 		mock,
+		outputs,
 		module,
 	};
 };

--- a/tests/src/usecases/budget.spec.ts
+++ b/tests/src/usecases/budget.spec.ts
@@ -436,6 +436,41 @@ describe('Usecases > Budget', () => {
 				remainingBudget: -130,
 			});
 			expect(result.budgetByCategory).toHaveLength(3);
+			expect(result.budgetByCategory).toStrictEqual([
+				{
+					active: true,
+					color: 'red',
+					description: 'description',
+					icon: 'bank',
+					id: 1,
+					name: 'Category A',
+					remainingBudget: -150,
+					totalBudget: -50,
+					totalExpenses: 100,
+				},
+				{
+					active: true,
+					color: 'red',
+					description: 'description',
+					icon: 'bank',
+					id: 2,
+					name: 'Category B',
+					remainingBudget: 70,
+					totalBudget: 20,
+					totalExpenses: -50,
+				},
+				{
+					active: true,
+					color: 'red',
+					description: 'description',
+					icon: 'bank',
+					id: 3,
+					name: 'Category C',
+					remainingBudget: -50,
+					totalBudget: 150,
+					totalExpenses: 200,
+				},
+			]);
 		});
 	});
 

--- a/tests/src/usecases/budget.spec.ts
+++ b/tests/src/usecases/budget.spec.ts
@@ -495,7 +495,7 @@ describe('Usecases > Budget', () => {
 	});
 
 	describe('> createNextBudgetDates', () => {
-		it('', async () => {
+		it('should generates future budget dates for a specific budget', async () => {
 			const input = {
 				startFrom: {
 					id: '1',

--- a/tests/src/usecases/budget.spec.ts
+++ b/tests/src/usecases/budget.spec.ts
@@ -1,0 +1,544 @@
+import type { INestApplication } from '@nestjs/common';
+import { createTestModule, createTestService } from '../../utils';
+import { BudgetService } from 'usecases/budget/budget.service';
+import { BudgetModule } from 'usecases/budget/budget.module';
+import { makeBudgetRepositoryMock } from '../../mocks/repositories/postgres/budget';
+import { makeCategoryRepositoryMock } from '../../mocks/repositories/postgres/category';
+import { makeTransactionRepositoryMock } from '../../mocks/repositories/postgres/transaction';
+import { makeAccountServiceMock } from '../../mocks/usecases/account';
+import { makeDayjsAdapterMock } from '../../mocks/adapters/dayjs';
+import { DayjsAdapterService } from 'adapters/implementations/dayjs/dayjs.service';
+
+describe('Usecases > Budget', () => {
+	let service: BudgetService;
+	let module: INestApplication;
+
+	const budgetRepository = makeBudgetRepositoryMock();
+	const categoryRepository = makeCategoryRepositoryMock();
+	const transactionRepository = makeTransactionRepositoryMock();
+	const accountService = makeAccountServiceMock();
+	const dayjsAdapter = makeDayjsAdapterMock();
+
+	beforeAll(async () => {
+		try {
+			service = await createTestService<BudgetService>(BudgetService, {
+				providers: [
+					budgetRepository.module,
+					categoryRepository.module,
+					transactionRepository.module,
+					accountService.module,
+					dayjsAdapter.module,
+				],
+			});
+
+			module = await createTestModule(BudgetModule);
+		} catch (err) {
+			console.error(err);
+		}
+	});
+
+	beforeEach(() => {
+		budgetRepository.mock.createWithItems.mockResolvedValue(
+			budgetRepository.outputs.createWithItems,
+		);
+		accountService.mock.setBudget.mockResolvedValue(null);
+		budgetRepository.mock.upsertManyBudgetDates.mockResolvedValue(
+			budgetRepository.outputs.upsertManyBudgetDates,
+		);
+		categoryRepository.mock.getByUser.mockResolvedValue(
+			categoryRepository.outputs.getByUser,
+		);
+		budgetRepository.mock.getMonthlyByCategory.mockResolvedValue(
+			budgetRepository.outputs.getMonthlyByCategory,
+		);
+		transactionRepository.mock.getMonthlyAmountByCategory.mockResolvedValue(
+			transactionRepository.outputs.getMonthlyAmountByCategory,
+		);
+		dayjsAdapter.mock.startOf.mockReturnValue(2);
+	});
+
+	describe('definitions', () => {
+		it('should initialize Service', () => {
+			expect(service).toBeDefined();
+		});
+		it('should initialize Module', async () => {
+			expect(module).toBeDefined();
+		});
+	});
+
+	describe('create', () => {
+		it('should create a budget successfully', async () => {
+			const input = {
+				accountId: 'accountId',
+				name: 'name',
+				description: 'description',
+				year: 2024,
+				months: [
+					{ month: 1, items: [] },
+					{ month: 2, items: [] },
+				],
+			};
+
+			const spyOn1 = jest.spyOn(accountService.mock, 'setBudget');
+			const spyOn2 = jest.spyOn(budgetRepository.mock, 'createWithItems');
+			let result;
+			try {
+				result = await service.create(input);
+			} catch (err) {
+				result = err;
+			}
+			expect(result).toStrictEqual({
+				accountId: 'accountId',
+				description: 'Test Budget Description',
+				id: '1',
+				name: 'Test Budget',
+			});
+			expect(spyOn1).toHaveBeenCalled();
+			expect(spyOn1).toHaveBeenCalledWith({
+				accountId: 'accountId',
+				budgetId: '1',
+			});
+			expect(spyOn2).toHaveBeenCalledWith({
+				accountId: 'accountId',
+				name: 'name',
+				description: 'description',
+				months: [
+					{
+						items: [],
+						month: 1,
+						year: 2024,
+					},
+					{
+						items: [],
+						month: 2,
+						year: 2024,
+					},
+				],
+			});
+		});
+
+		it('should throw an exception if creating budget fails', async () => {
+			const input = {
+				accountId: '1',
+				name: 'name',
+				description: 'description',
+				year: 2024,
+				months: [
+					{ month: 1, items: [] },
+					{ month: 2, items: [] },
+				],
+			};
+
+			// Simular falha ao criar o orçamento
+			const psyOnCreateWithItems = jest
+				.spyOn(budgetRepository.mock, 'createWithItems')
+				.mockRejectedValue(new Error('Failed to create budget'));
+
+			// Simular chamada ao método setBudget do serviço de conta
+			const spyOn = jest.spyOn(accountService.mock, 'setBudget');
+			// Chamar o método create e capturar a exceção
+			let result;
+			try {
+				result = await service.create(input);
+			} catch (err) {
+				result = err;
+			}
+
+			// Verificar se uma exceção foi lançada
+			expect(result).toBeInstanceOf(Error);
+			expect(spyOn).not.toHaveBeenCalled();
+			expect(psyOnCreateWithItems).toHaveBeenCalledTimes(1);
+		});
+
+		it('deve criar um orçamento com o limite máximo de meses', async () => {
+			// Defina o limite máximo de meses
+			const MAX_MONTHS = 12;
+
+			// Crie uma entrada com o limite máximo de meses
+			const input = {
+				accountId: 'accountId',
+				name: 'Test Budget',
+				description: 'Test Budget Description',
+				year: 2024,
+				months: Array.from({ length: MAX_MONTHS }, (_, index) => ({
+					month: index + 1,
+					items: [], // Supondo que não há itens para este teste
+				})),
+			};
+
+			let result;
+			try {
+				result = await service.create(input);
+			} catch (err) {
+				result = err;
+			}
+
+			// Verifique se o orçamento foi criado corretamente
+			expect(result).toBeDefined();
+			expect(budgetRepository.mock.createWithItems).toHaveBeenCalledWith({
+				accountId: 'accountId',
+				name: 'Test Budget',
+				description: 'Test Budget Description',
+				months: input.months.map(({ month, items }) => ({
+					month,
+					year: input.year,
+					items,
+				})),
+			});
+		});
+	});
+
+	describe('getOrCreateMany', () => {
+		it('should creates new budget dates', async () => {
+			const input = {
+				budgetId: '1',
+				accountId: '1',
+				dates: [new Date(2024, 2, 1)],
+			};
+
+			const newBudgetDates = [
+				{
+					id: '1',
+					budgetId: '1',
+					month: 1,
+					year: 2024,
+					date: new Date(2024, 1, 24, 3, 0, 0),
+				},
+			];
+			dayjsAdapter.mock.get.mockReturnValueOnce(2).mockReturnValueOnce(2024);
+			let result;
+			try {
+				result = await service.getOrCreateMany(input);
+			} catch (err) {
+				result = err;
+			}
+			expect(result).toStrictEqual(newBudgetDates);
+			expect(budgetRepository.mock.upsertManyBudgetDates).toHaveBeenCalledWith([
+				{
+					budgetId: '1',
+					month: 2,
+					year: 2024,
+					date: 2,
+				},
+			]);
+		});
+	});
+
+	describe('createBasic', () => {
+		it('should creates new budget basic with items', async () => {
+			const input = {
+				accountId: 'accountId',
+				name: 'string',
+				description: 'Test Budget Description',
+				year: 2024,
+				items: [
+					{ categoryId: '1', amount: 100 },
+					{ categoryId: '2', amount: 100 },
+				],
+			};
+
+			let result;
+			try {
+				result = await service.createBasic(input);
+			} catch (err) {
+				result = err;
+			}
+			const itemsFormatted = input.items
+				.map(({ categoryId, amount }) =>
+					Array(12)
+						.fill(null)
+						.map((_, idx) => ({
+							month: idx + 1,
+							year: input.year,
+							items: [
+								{
+									categoryId,
+									amount,
+								},
+							],
+						})),
+				)
+				.flat();
+			expect(result).toStrictEqual({
+				id: '1',
+				accountId: 'accountId',
+				name: 'Test Budget',
+				description: 'Test Budget Description',
+			});
+			expect(accountService.mock.setBudget).toHaveBeenCalled();
+			expect(accountService.mock.setBudget).toHaveBeenCalledWith({
+				accountId: input.accountId,
+				budgetId: budgetRepository.outputs.createWithItems.id,
+			});
+			expect(budgetRepository.mock.createWithItems).toHaveBeenCalledWith({
+				accountId: 'accountId',
+				name: 'string',
+				description: 'Test Budget Description',
+				months: itemsFormatted,
+			});
+		});
+	});
+
+	describe('overview', () => {
+		it('should correctly handle active categories with expenses', async () => {
+			const input = {
+				accountId: 'exemploAccountId',
+				budgetId: '1',
+				month: 2,
+				year: 2024,
+			};
+
+			const mockCategories = [
+				{ id: 1, name: 'Categoria A', active: true },
+				{ id: 2, name: 'Categoria B', active: true },
+				{ id: 3, name: 'Categoria C', active: true },
+			];
+
+			const mockBudgets = [
+				{ categoryId: 1, amount: 100 },
+				{ categoryId: 2, amount: 200 },
+				{ categoryId: 3, amount: 150 },
+			];
+
+			const mockExpenses = [
+				{ categoryId: 1, amount: 50 },
+				{ categoryId: 2, amount: 0 }, // Despesa zero
+				{ categoryId: 3, amount: 100 },
+			];
+
+			categoryRepository.mock.getByUser.mockResolvedValue(mockCategories);
+			budgetRepository.mock.getMonthlyByCategory.mockResolvedValue(mockBudgets);
+			transactionRepository.mock.getMonthlyAmountByCategory.mockResolvedValue(
+				mockExpenses,
+			);
+			let result;
+			try {
+				result = await service.overview(input);
+			} catch (err) {
+				result = err;
+			}
+
+			expect(categoryRepository.mock.getByUser).toHaveBeenCalledWith({
+				accountId: input.accountId,
+				limit: 10000,
+				offset: 0,
+			});
+			expect(budgetRepository.mock.getMonthlyByCategory).toHaveBeenCalledWith(
+				input,
+			);
+			expect(
+				transactionRepository.mock.getMonthlyAmountByCategory,
+			).toHaveBeenCalledWith(input);
+
+			expect(result.totalBudget).toEqual(450);
+			expect(result.totalExpenses).toEqual(150);
+			expect(result.remainingBudget).toEqual(300);
+			expect(result.budgetByCategory).toHaveLength(3);
+			expect(result.budgetByCategory).toEqual([
+				{
+					id: 1,
+					name: 'Categoria A',
+					active: true,
+					totalExpenses: 50,
+					totalBudget: 100,
+					remainingBudget: 50,
+				},
+				{
+					id: 2,
+					name: 'Categoria B',
+					active: true,
+					totalExpenses: 0,
+					totalBudget: 200,
+					remainingBudget: 200,
+				},
+				{
+					id: 3,
+					name: 'Categoria C',
+					active: true,
+					totalExpenses: 100,
+					totalBudget: 150,
+					remainingBudget: 50,
+				},
+			]);
+		});
+
+		it('should correctly handle inactive categories with expenses', async () => {
+			const input = {
+				accountId: 'exemploAccountId',
+				budgetId: '1',
+				month: 2,
+				year: 2024,
+			};
+
+			const mockCategories = [
+				{ id: 1, name: 'Categoria A', active: false },
+				{ id: 2, name: 'Categoria B', active: false },
+				{ id: 3, name: 'Categoria C', active: false },
+			];
+
+			const mockBudgets = [
+				{ categoryId: 1, amount: 100 },
+				{ categoryId: 2, amount: 200 },
+				{ categoryId: 3, amount: 150 },
+			];
+
+			const mockExpenses = [
+				{ categoryId: 1, amount: 50 },
+				{ categoryId: 2, amount: 0 }, // Despesa zero
+				{ categoryId: 3, amount: 100 },
+			];
+
+			categoryRepository.mock.getByUser.mockResolvedValue(mockCategories);
+			budgetRepository.mock.getMonthlyByCategory.mockResolvedValue(mockBudgets);
+			transactionRepository.mock.getMonthlyAmountByCategory.mockResolvedValue(
+				mockExpenses,
+			);
+
+			let result;
+			try {
+				result = await service.overview(input);
+			} catch (err) {
+				result = err;
+			}
+
+			expect(categoryRepository.mock.getByUser).toHaveBeenCalledWith({
+				accountId: input.accountId,
+				limit: 10000,
+				offset: 0,
+			});
+			expect(budgetRepository.mock.getMonthlyByCategory).toHaveBeenCalledWith(
+				input,
+			);
+			expect(
+				transactionRepository.mock.getMonthlyAmountByCategory,
+			).toHaveBeenCalledWith(input);
+
+			expect(result.totalBudget).toEqual(450);
+			expect(result.totalExpenses).toEqual(150);
+			expect(result.remainingBudget).toEqual(300);
+			expect(result.budgetByCategory).toHaveLength(2);
+			expect(result.budgetByCategory).toEqual([
+				{
+					id: 1,
+					name: 'Categoria A',
+					active: false,
+					totalExpenses: 50,
+					totalBudget: 100,
+					remainingBudget: 50,
+				},
+				{
+					id: 3,
+					name: 'Categoria C',
+					active: false,
+					totalExpenses: 100,
+					totalBudget: 150,
+					remainingBudget: 50,
+				},
+			]);
+		});
+		it('should correctly handle negative budgets and expenses', async () => {
+			const input = {
+				accountId: 'exemploAccountId',
+				budgetId: '1',
+				month: 2,
+				year: 2024,
+			};
+
+			const mockCategories = [
+				{ id: 1, name: 'Categoria A', active: true },
+				{ id: 2, name: 'Categoria B', active: true },
+				{ id: 3, name: 'Categoria C', active: true },
+			];
+
+			const mockBudgets = [
+				{ categoryId: 1, amount: -50 }, // Orçamento negativo
+				{ categoryId: 2, amount: 20 },
+				{ categoryId: 3, amount: 150 },
+			];
+
+			const mockExpenses = [
+				{ categoryId: 1, amount: 100 }, // Despesa positiva
+				{ categoryId: 2, amount: -50 }, // Despesa negativa
+				{ categoryId: 3, amount: 200 }, // Despesa positiva
+			];
+
+			categoryRepository.mock.getByUser.mockResolvedValue(mockCategories);
+			budgetRepository.mock.getMonthlyByCategory.mockResolvedValue(mockBudgets);
+			transactionRepository.mock.getMonthlyAmountByCategory.mockResolvedValue(
+				mockExpenses,
+			);
+
+			let result;
+			try {
+				result = await service.overview(input);
+			} catch (err) {
+				result = err;
+			}
+
+			expect(categoryRepository.mock.getByUser).toHaveBeenCalledWith({
+				accountId: input.accountId,
+				limit: 10000,
+				offset: 0,
+			});
+			expect(budgetRepository.mock.getMonthlyByCategory).toHaveBeenCalledWith(
+				input,
+			);
+			expect(
+				transactionRepository.mock.getMonthlyAmountByCategory,
+			).toHaveBeenCalledWith(input);
+
+			expect(result.totalBudget).toEqual(120);
+			expect(result.totalExpenses).toEqual(250);
+			expect(result.remainingBudget).toEqual(-130);
+			expect(result.budgetByCategory).toHaveLength(3);
+		});
+	});
+
+	describe('> createNextBudgetDates', () => {
+		it('', async () => {
+			const input = {
+				startFrom: {
+					id: '1',
+					budgetId: '1',
+					month: 2,
+					year: 2024,
+					date: new Date(2024, 3, 2),
+				},
+				amount: 20,
+			};
+			let result;
+			const dates = Array.from({ length: input.amount }, (_, index) => {
+				const currentDate = new Date(input.startFrom.date);
+				currentDate.setMonth(currentDate.getMonth() + index);
+				return currentDate.toISOString();
+			});
+			dayjsAdapter.mock.getNextMonths.mockReturnValue(dates);
+			for (let index = 0; index < input.amount; index++) {
+				console.log(new Date(dates[index]).getMonth() + 1);
+				dayjsAdapter.mock.get
+					.mockReturnValueOnce(new Date(dates[index]).getMonth() + 1)
+					.mockReturnValueOnce(new Date(dates[index]).getFullYear());
+			}
+
+			try {
+				result = await service.createNextBudgetDates(input);
+			} catch (err) {
+				result = err;
+			}
+
+			const lastArgument =
+				budgetRepository.mock.upsertManyBudgetDates.mock.calls[0][0].slice(
+					-1,
+				)[0];
+			expect(lastArgument).toEqual({
+				budgetId: '1',
+				date: dates[input.amount - 1],
+				month: 11,
+				year: 2025,
+			});
+			expect(
+				budgetRepository.mock.upsertManyBudgetDates.mock.calls[0][0].length,
+			).toEqual(20);
+		});
+	});
+});

--- a/tests/src/usecases/budget.spec.ts
+++ b/tests/src/usecases/budget.spec.ts
@@ -291,10 +291,11 @@ describe('Usecases > Budget', () => {
 				transactionRepository.mock.getMonthlyAmountByCategory,
 			).toHaveBeenCalledWith(input);
 
-			expect(result.totalBudget).toEqual(450);
-			expect(result.totalExpenses).toEqual(150);
-			expect(result.remainingBudget).toEqual(300);
-			expect(result.budgetByCategory).toHaveLength(3);
+			expect(result).toMatchObject({
+				totalBudget: 450,
+				totalExpenses: 150,
+				remainingBudget: 300,
+			});
 			expect(result.budgetByCategory).toEqual([
 				{
 					id: 1,
@@ -362,10 +363,13 @@ describe('Usecases > Budget', () => {
 			expect(
 				transactionRepository.mock.getMonthlyAmountByCategory,
 			).toHaveBeenCalledWith(input);
-			expect(result.totalBudget).toEqual(450);
-			expect(result.totalExpenses).toEqual(150);
-			expect(result.remainingBudget).toEqual(300);
+
 			expect(result.budgetByCategory).toHaveLength(2);
+			expect(result).toMatchObject({
+				totalBudget: 450,
+				totalExpenses: 150,
+				remainingBudget: 300,
+			});
 			expect(result.budgetByCategory).toEqual([
 				{
 					id: 1,
@@ -426,9 +430,11 @@ describe('Usecases > Budget', () => {
 				transactionRepository.mock.getMonthlyAmountByCategory,
 			).toHaveBeenCalledWith(input);
 
-			expect(result.totalBudget).toEqual(120);
-			expect(result.totalExpenses).toEqual(250);
-			expect(result.remainingBudget).toEqual(-130);
+			expect(result).toMatchObject({
+				totalBudget: 120,
+				totalExpenses: 250,
+				remainingBudget: -130,
+			});
 			expect(result.budgetByCategory).toHaveLength(3);
 		});
 	});
@@ -443,13 +449,24 @@ describe('Usecases > Budget', () => {
 					year: 2024,
 					date: new Date(2024, 3, 2),
 				},
-				amount: 20,
+				amount: 14,
 			};
-			const dates = Array.from({ length: input.amount }, (_, index) => {
-				const currentDate = new Date(input.startFrom.date);
-				currentDate.setMonth(currentDate.getMonth() + index);
-				return currentDate.toISOString();
-			});
+			const dates = [
+				'2024-04-02T03:00:00.000Z',
+				'2024-05-02T03:00:00.000Z',
+				'2024-06-02T03:00:00.000Z',
+				'2024-07-02T03:00:00.000Z',
+				'2024-08-02T03:00:00.000Z',
+				'2024-09-02T03:00:00.000Z',
+				'2024-10-02T03:00:00.000Z',
+				'2024-11-02T03:00:00.000Z',
+				'2024-12-02T03:00:00.000Z',
+				'2025-01-02T03:00:00.000Z',
+				'2025-02-02T03:00:00.000Z',
+				'2025-03-02T03:00:00.000Z',
+				'2025-04-02T03:00:00.000Z',
+				'2025-05-02T03:00:00.000Z',
+			];
 			dayjsAdapter.mock.getNextMonths.mockReturnValue(dates);
 			for (let index = 0; index < input.amount; index++) {
 				dayjsAdapter.mock.get
@@ -470,12 +487,12 @@ describe('Usecases > Budget', () => {
 			).toEqual({
 				budgetId: '1',
 				date: dates[input.amount - 1],
-				month: 11,
+				month: 5,
 				year: 2025,
 			});
 			expect(
 				budgetRepository.mock.upsertManyBudgetDates.mock.calls[0][0].length,
-			).toEqual(20);
+			).toEqual(14);
 		});
 	});
 });

--- a/tests/src/usecases/budget.spec.ts
+++ b/tests/src/usecases/budget.spec.ts
@@ -7,7 +7,6 @@ import { makeCategoryRepositoryMock } from '../../mocks/repositories/postgres/ca
 import { makeTransactionRepositoryMock } from '../../mocks/repositories/postgres/transaction';
 import { makeAccountServiceMock } from '../../mocks/usecases/account';
 import { makeDayjsAdapterMock } from '../../mocks/adapters/dayjs';
-import { DayjsAdapterService } from 'adapters/implementations/dayjs/dayjs.service';
 
 describe('Usecases > Budget', () => {
 	let service: BudgetService;
@@ -506,7 +505,6 @@ describe('Usecases > Budget', () => {
 				},
 				amount: 20,
 			};
-			let result;
 			const dates = Array.from({ length: input.amount }, (_, index) => {
 				const currentDate = new Date(input.startFrom.date);
 				currentDate.setMonth(currentDate.getMonth() + index);
@@ -514,12 +512,11 @@ describe('Usecases > Budget', () => {
 			});
 			dayjsAdapter.mock.getNextMonths.mockReturnValue(dates);
 			for (let index = 0; index < input.amount; index++) {
-				console.log(new Date(dates[index]).getMonth() + 1);
 				dayjsAdapter.mock.get
 					.mockReturnValueOnce(new Date(dates[index]).getMonth() + 1)
 					.mockReturnValueOnce(new Date(dates[index]).getFullYear());
 			}
-
+			let result;
 			try {
 				result = await service.createNextBudgetDates(input);
 			} catch (err) {


### PR DESCRIPTION
tests: Add tests for budget-related use cases

Add unit and integration tests for use cases related to the budget module. This includes testing for creating a budget, getting or creating budget dates, creating a basic budget with items, budget overview, and creating future budget dates.

- Tests to create a successful budget
- Tests to handle exceptions when creating a budget fails
- Tests to create a budget with the maximum number of months
- Tests to create new budget dates
- Tests to create a basic budget with items
- Tests for the budget overview
- Tests to create future budget dates

Each test validates the different scenarios and expected behaviors of budget-related use cases, ensuring the robustness and reliability of the code.
